### PR TITLE
dnf5 install command fixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -55,13 +55,13 @@ main() {
         show $sudo apt-get install -y brave-browser
 
     elif available dnf; then
-      if dnf --version|grep -q dnf5; then
-      show $sudo dnf config-manager addrepo --overwrite --from-repofile=https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
+        if dnf --version|grep -q dnf5; then
+            show $sudo dnf config-manager addrepo --overwrite --from-repofile=https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
         else
-        show $sudo dnf install -y 'dnf-command(config-manager)'
+            show $sudo dnf install -y 'dnf-command(config-manager)'
             show $sudo dnf config-manager --add-repo https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
         fi
-        show $sudo dnf install -y brave-browser
+            show $sudo dnf install -y brave-browser
 
     elif available eopkg; then
         show $sudo eopkg update-repo -y

--- a/install.sh
+++ b/install.sh
@@ -55,10 +55,10 @@ main() {
         show $sudo apt-get install -y brave-browser
 
     elif available dnf; then
-        show $sudo dnf install -y 'dnf-command(config-manager)'
-        if dnf --version|grep -q dnf5; then
-            show $sudo dnf config-manager addrepo --overwrite --from-repofile=https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
+      if dnf --version|grep -q dnf5; then
+      show $sudo dnf config-manager addrepo --overwrite --from-repofile=https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
         else
+        show $sudo dnf install -y 'dnf-command(config-manager)'
             show $sudo dnf config-manager --add-repo https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
         fi
         show $sudo dnf install -y brave-browser


### PR DESCRIPTION
Now for dnf5 users, running a standard install will add python plugins and unnecessary dependencies to the system, since dnf5 users (fedora 41 and above), have dnf5-plugins built in.