### PR TITLE
Remove TLS version restriction in curl

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ main() {
 
     case "$(first_of curl wget)" in
         wget) curl="wget -qO-";;
-        *) curl="curl -fsS --proto =https --tlsv1.3";;
+        *) curl="curl -fsS";;
     esac
 
     ## Validate the browser channel


### PR DESCRIPTION
This doesn't really buy us anything security-wise because the [original curl command](https://brave.com/linux/) used to fetch `install.sh` doesn't have it. An attacker doing a downgrade attack could simply edit this line in the resulting `install.sh` too.

It has also [prevented a user from installing Brave](https://community.brave.app/t/update-problems-with-brave-on-fedora42-with-kde/642748/2).